### PR TITLE
Fix to get history backwards from the latest one to older ones

### DIFF
--- a/autoload/ddc_cmdline_history.vim
+++ b/autoload/ddc_cmdline_history.vim
@@ -5,5 +5,5 @@ function! ddc_cmdline_history#get(max) abort
     return []
   endif
   return map(range(1, max),
-        \ { _, val -> histget(type, val) })
+        \ { _, val -> histget(type, - val) })
 endfunction

--- a/denops/@ddc-sources/cmdline-history.ts
+++ b/denops/@ddc-sources/cmdline-history.ts
@@ -33,7 +33,7 @@ export class Source extends BaseSource<Params> {
         word.startsWith(input) && word.indexOf("\r") < 0 &&
         word.indexOf("\n") < 0,
     )
-      .map((word) => ({ word: word.substring(inputLength) })).reverse();
+      .map((word) => ({ word: word.substring(inputLength) }));
   }
 
   params(): Params {


### PR DESCRIPTION
According to `:h :history-indexing`, negative index counts backwards from the newest entry of history.